### PR TITLE
[IT-3253] Update memory even more to at least be comparable to a mac

### DIFF
--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -81,11 +81,11 @@ class DockerFargateStack(Stack):
             self,
             f'{stack_prefix}-Service',
             cluster=cluster,            # Required
-            cpu=2048,                    # Default is 256
+            cpu=4096,                    # Default is 256
             desired_count=1,            # Number of copies of the 'task' (i.e. the app') running behind the ALB
             circuit_breaker=ecs.DeploymentCircuitBreaker(rollback=True), # Enable rollback on deployment failure
             task_image_options=task_image_options,
-            memory_limit_mib=8192,      # Default is 512
+            memory_limit_mib=16384,      # Default is 512
             public_load_balancer=True,  # Default is False
             # TLS:
             certificate=cert,


### PR DESCRIPTION
PR Checklist:
- [x] Describe and explain your intentions for this change
- [x] Setup pre-commit and run the validators (info in README.md)

Even though none of the code changed, the data size got larger.  When i bumped the memory, I was able to get one of the filters on a subset of data to load, but not on all of the data.  (filter set to ALL)

This indicates that i need to further bump the memory